### PR TITLE
feat: LA-Cosmic 残差確認機能と gain/readnoise 設定を追加

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1535,6 +1535,98 @@ files = [
 ]
 
 [[package]]
+name = "pandas"
+version = "3.0.1"
+description = "Powerful data structures for data analysis, time series, and statistics"
+optional = false
+python-versions = ">=3.11"
+groups = ["main"]
+files = [
+    {file = "pandas-3.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:de09668c1bf3b925c07e5762291602f0d789eca1b3a781f99c1c78f6cac0e7ea"},
+    {file = "pandas-3.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:24ba315ba3d6e5806063ac6eb717504e499ce30bd8c236d8693a5fd3f084c796"},
+    {file = "pandas-3.0.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:406ce835c55bac912f2a0dcfaf27c06d73c6b04a5dde45f1fd3169ce31337389"},
+    {file = "pandas-3.0.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:830994d7e1f31dd7e790045235605ab61cff6c94defc774547e8b7fdfbff3dc7"},
+    {file = "pandas-3.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a64ce8b0f2de1d2efd2ae40b0abe7f8ae6b29fbfb3812098ed5a6f8e235ad9bf"},
+    {file = "pandas-3.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9832c2c69da24b602c32e0c7b1b508a03949c18ba08d4d9f1c1033426685b447"},
+    {file = "pandas-3.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:84f0904a69e7365f79a0c77d3cdfccbfb05bf87847e3a51a41e1426b0edb9c79"},
+    {file = "pandas-3.0.1-cp311-cp311-win_arm64.whl", hash = "sha256:4a68773d5a778afb31d12e34f7dd4612ab90de8c6fb1d8ffe5d4a03b955082a1"},
+    {file = "pandas-3.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:476f84f8c20c9f5bc47252b66b4bb25e1a9fc2fa98cead96744d8116cb85771d"},
+    {file = "pandas-3.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0ab749dfba921edf641d4036c4c21c0b3ea70fea478165cb98a998fb2a261955"},
+    {file = "pandas-3.0.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8e36891080b87823aff3640c78649b91b8ff6eea3c0d70aeabd72ea43ab069b"},
+    {file = "pandas-3.0.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:532527a701281b9dd371e2f582ed9094f4c12dd9ffb82c0c54ee28d8ac9520c4"},
+    {file = "pandas-3.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:356e5c055ed9b0da1580d465657bc7d00635af4fd47f30afb23025352ba764d1"},
+    {file = "pandas-3.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9d810036895f9ad6345b8f2a338dd6998a74e8483847403582cab67745bff821"},
+    {file = "pandas-3.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:536232a5fe26dd989bd633e7a0c450705fdc86a207fec7254a55e9a22950fe43"},
+    {file = "pandas-3.0.1-cp312-cp312-win_arm64.whl", hash = "sha256:0f463ebfd8de7f326d38037c7363c6dacb857c5881ab8961fb387804d6daf2f7"},
+    {file = "pandas-3.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5272627187b5d9c20e55d27caf5f2cd23e286aba25cadf73c8590e432e2b7262"},
+    {file = "pandas-3.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:661e0f665932af88c7877f31da0dc743fe9c8f2524bdffe23d24fdcb67ef9d56"},
+    {file = "pandas-3.0.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:75e6e292ff898679e47a2199172593d9f6107fd2dd3617c22c2946e97d5df46e"},
+    {file = "pandas-3.0.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1ff8cf1d2896e34343197685f432450ec99a85ba8d90cce2030c5eee2ef98791"},
+    {file = "pandas-3.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:eca8b4510f6763f3d37359c2105df03a7a221a508f30e396a51d0713d462e68a"},
+    {file = "pandas-3.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:06aff2ad6f0b94a17822cf8b83bbb563b090ed82ff4fe7712db2ce57cd50d9b8"},
+    {file = "pandas-3.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:9fea306c783e28884c29057a1d9baa11a349bbf99538ec1da44c8476563d1b25"},
+    {file = "pandas-3.0.1-cp313-cp313-win_arm64.whl", hash = "sha256:a8d37a43c52917427e897cb2e429f67a449327394396a81034a4449b99afda59"},
+    {file = "pandas-3.0.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d54855f04f8246ed7b6fc96b05d4871591143c46c0b6f4af874764ed0d2d6f06"},
+    {file = "pandas-3.0.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4e1b677accee34a09e0dc2ce5624e4a58a1870ffe56fc021e9caf7f23cd7668f"},
+    {file = "pandas-3.0.1-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a9cabbdcd03f1b6cd254d6dda8ae09b0252524be1592594c00b7895916cb1324"},
+    {file = "pandas-3.0.1-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ae2ab1f166668b41e770650101e7090824fd34d17915dd9cd479f5c5e0065e9"},
+    {file = "pandas-3.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6bf0603c2e30e2cafac32807b06435f28741135cb8697eae8b28c7d492fc7d76"},
+    {file = "pandas-3.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6c426422973973cae1f4a23e51d4ae85974f44871b24844e4f7de752dd877098"},
+    {file = "pandas-3.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:b03f91ae8c10a85c1613102c7bef5229b5379f343030a3ccefeca8a33414cf35"},
+    {file = "pandas-3.0.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:99d0f92ed92d3083d140bf6b97774f9f13863924cf3f52a70711f4e7588f9d0a"},
+    {file = "pandas-3.0.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3b66857e983208654294bb6477b8a63dee26b37bdd0eb34d010556e91261784f"},
+    {file = "pandas-3.0.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:56cf59638bf24dc9bdf2154c81e248b3289f9a09a6d04e63608c159022352749"},
+    {file = "pandas-3.0.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1a9f55e0f46951874b863d1f3906dcb57df2d9be5c5847ba4dfb55b2c815249"},
+    {file = "pandas-3.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1849f0bba9c8a2fb0f691d492b834cc8dadf617e29015c66e989448d58d011ee"},
+    {file = "pandas-3.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c3d288439e11b5325b02ae6e9cc83e6805a62c40c5a6220bea9beb899c073b1c"},
+    {file = "pandas-3.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:93325b0fe372d192965f4cca88d97667f49557398bbf94abdda3bf1b591dbe66"},
+    {file = "pandas-3.0.1-cp314-cp314-win_arm64.whl", hash = "sha256:97ca08674e3287c7148f4858b01136f8bdfe7202ad25ad04fec602dd1d29d132"},
+    {file = "pandas-3.0.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:58eeb1b2e0fb322befcf2bbc9ba0af41e616abadb3d3414a6bc7167f6cbfce32"},
+    {file = "pandas-3.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cd9af1276b5ca9e298bd79a26bda32fa9cc87ed095b2a9a60978d2ca058eaf87"},
+    {file = "pandas-3.0.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94f87a04984d6b63788327cd9f79dda62b7f9043909d2440ceccf709249ca988"},
+    {file = "pandas-3.0.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:85fe4c4df62e1e20f9db6ebfb88c844b092c22cd5324bdcf94bfa2fc1b391221"},
+    {file = "pandas-3.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:331ca75a2f8672c365ae25c0b29e46f5ac0c6551fdace8eec4cd65e4fac271ff"},
+    {file = "pandas-3.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:15860b1fdb1973fffade772fdb931ccf9b2f400a3f5665aef94a00445d7d8dd5"},
+    {file = "pandas-3.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:44f1364411d5670efa692b146c748f4ed013df91ee91e9bec5677fb1fd58b937"},
+    {file = "pandas-3.0.1-cp314-cp314t-win_arm64.whl", hash = "sha256:108dd1790337a494aa80e38def654ca3f0968cf4f362c85f44c15e471667102d"},
+    {file = "pandas-3.0.1.tar.gz", hash = "sha256:4186a699674af418f655dbd420ed87f50d56b4cd6603784279d9eef6627823c8"},
+]
+
+[package.dependencies]
+numpy = [
+    {version = ">=1.26.0", markers = "python_version < \"3.14\""},
+    {version = ">=2.3.3", markers = "python_version >= \"3.14\""},
+]
+python-dateutil = ">=2.8.2"
+tzdata = {version = "*", markers = "sys_platform == \"win32\" or sys_platform == \"emscripten\""}
+
+[package.extras]
+all = ["PyQt5 (>=5.15.9)", "SQLAlchemy (>=2.0.36)", "adbc-driver-postgresql (>=1.2.0)", "adbc-driver-sqlite (>=1.2.0)", "beautifulsoup4 (>=4.12.3)", "bottleneck (>=1.4.2)", "fastparquet (>=2024.11.0)", "fsspec (>=2024.10.0)", "gcsfs (>=2024.10.0)", "html5lib (>=1.1)", "hypothesis (>=6.116.0)", "jinja2 (>=3.1.5)", "lxml (>=5.3.0)", "matplotlib (>=3.9.3)", "numba (>=0.60.0)", "numexpr (>=2.10.2)", "odfpy (>=1.4.1)", "openpyxl (>=3.1.5)", "psycopg2 (>=2.9.10)", "pyarrow (>=13.0.0)", "pyiceberg (>=0.8.1)", "pymysql (>=1.1.1)", "pyreadstat (>=1.2.8)", "pytest (>=8.3.4)", "pytest-xdist (>=3.6.1)", "python-calamine (>=0.3.0)", "pytz (>=2024.2)", "pyxlsb (>=1.0.10)", "qtpy (>=2.4.2)", "s3fs (>=2024.10.0)", "scipy (>=1.14.1)", "tables (>=3.10.1)", "tabulate (>=0.9.0)", "xarray (>=2024.10.0)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.2.0)", "zstandard (>=0.23.0)"]
+aws = ["s3fs (>=2024.10.0)"]
+clipboard = ["PyQt5 (>=5.15.9)", "qtpy (>=2.4.2)"]
+compression = ["zstandard (>=0.23.0)"]
+computation = ["scipy (>=1.14.1)", "xarray (>=2024.10.0)"]
+excel = ["odfpy (>=1.4.1)", "openpyxl (>=3.1.5)", "python-calamine (>=0.3.0)", "pyxlsb (>=1.0.10)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.2.0)"]
+feather = ["pyarrow (>=13.0.0)"]
+fss = ["fsspec (>=2024.10.0)"]
+gcp = ["gcsfs (>=2024.10.0)"]
+hdf5 = ["tables (>=3.10.1)"]
+html = ["beautifulsoup4 (>=4.12.3)", "html5lib (>=1.1)", "lxml (>=5.3.0)"]
+iceberg = ["pyiceberg (>=0.8.1)"]
+mysql = ["SQLAlchemy (>=2.0.36)", "pymysql (>=1.1.1)"]
+output-formatting = ["jinja2 (>=3.1.5)", "tabulate (>=0.9.0)"]
+parquet = ["pyarrow (>=13.0.0)"]
+performance = ["bottleneck (>=1.4.2)", "numba (>=0.60.0)", "numexpr (>=2.10.2)"]
+plot = ["matplotlib (>=3.9.3)"]
+postgresql = ["SQLAlchemy (>=2.0.36)", "adbc-driver-postgresql (>=1.2.0)", "psycopg2 (>=2.9.10)"]
+pyarrow = ["pyarrow (>=13.0.0)"]
+spss = ["pyreadstat (>=1.2.8)"]
+sql-other = ["SQLAlchemy (>=2.0.36)", "adbc-driver-postgresql (>=1.2.0)", "adbc-driver-sqlite (>=1.2.0)"]
+test = ["hypothesis (>=6.116.0)", "pytest (>=8.3.4)", "pytest-xdist (>=3.6.1)"]
+timezone = ["pytz (>=2024.2)"]
+xml = ["lxml (>=5.3.0)"]
+
+[[package]]
 name = "parso"
 version = "0.8.6"
 description = "A Python Parser"
@@ -2269,6 +2361,19 @@ files = [
 markers = {main = "extra == \"processing\" or extra == \"all\""}
 
 [[package]]
+name = "tzdata"
+version = "2025.3"
+description = "Provider of IANA time zone data"
+optional = false
+python-versions = ">=2"
+groups = ["main"]
+markers = "sys_platform == \"win32\" or sys_platform == \"emscripten\""
+files = [
+    {file = "tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1"},
+    {file = "tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -2320,4 +2425,4 @@ processing = ["scipy", "stistools"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13"
-content-hash = "447a63813e2312fd8c835f1430be42566200a072929fb886ab2528a6ad219349"
+content-hash = "7c3182afb28812c46470f6aacec70b66895799fc8fc15f1c1a2a7b5713291bb8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "numpy>=1.26",
     "astropy>=6.0",
     "matplotlib>=3.8",
+    "pandas (>=3.0.1,<4.0.0)",
 ]
 
 [project.optional-dependencies]

--- a/scripts/check_lacosmic_residual.py
+++ b/scripts/check_lacosmic_residual.py
@@ -1,0 +1,79 @@
+"""check_lacosmic_residual.py  ─  LA-Cosmic の残差を確認する.
+
+FLT（処理前）と LAC（LA-Cosmic 適用後）を読み込み、
+差分スペクトルで輝線フラックスの損失量を可視化する。
+
+ipython での実行:
+    %run scripts/check_lacosmic_residual.py
+
+セッション内で run_lacosmic.py を実行済みの場合は、
+ファイルを再読み込みせず in-memory オブジェクトを直接使うことも可能:
+
+    collection.plot_lacosmic_residual(
+        lac_collection, slit_index=SLIT_INDEX,
+        recession_velocity=RECESSION_VELOCITY,
+    )
+"""
+
+from pathlib import Path
+
+from stis_analysis.core.fits_reader import ReaderCollection
+from stis_analysis.core.instrument import InstrumentModel
+from stis_analysis.lacosmic import ImageCollection
+
+# ------------------------------------------------------------------ #
+# 設定（必要に応じて変更）
+# ------------------------------------------------------------------ #
+
+CRJ_DIR = Path("../../HST")           # _crj.fits があるルートディレクトリ
+LAC_DIR = Path("../../output/lac")    # _lac.fits があるディレクトリ
+
+CRJ_SUFFIX = "_crj"
+CRJ_DEPTH = 1    # HST/o56502010/o56502010_crj.fits の 1 階層下
+
+RECESSION_VELOCITY = 1148.0   # NGC1068 後退速度 [km/s]
+
+SLIT_INDEX = 10               # 確認するスリット行
+V_RANGE = (-3000.0, 3000.0)   # 速度表示範囲 [km/s]
+
+# ------------------------------------------------------------------ #
+
+# --- CRJ (処理前) の読み込み ---
+crj_instrument = InstrumentModel.load(
+    file_directory=str(CRJ_DIR),
+    suffix=CRJ_SUFFIX,
+    extension=".fits",
+    depth=CRJ_DEPTH,
+)
+crj_readers = ReaderCollection.from_paths(crj_instrument.path_list)
+crj_collection = ImageCollection.from_readers(crj_readers)
+
+print(f"CRJ files ({len(crj_collection.images)}):")
+for img in crj_collection.images:
+    print(f"  {img.filename}")
+
+# --- LAC (LA-Cosmic 適用後) の読み込み ---
+lac_instrument = InstrumentModel.load(
+    file_directory=str(LAC_DIR),
+    suffix="_lac",
+    extension=".fits",
+    depth=0,
+)
+lac_readers = ReaderCollection.from_paths(lac_instrument.path_list)
+lac_collection = ImageCollection.from_readers(lac_readers)
+
+print(f"\nLAC files ({len(lac_collection.images)}):")
+for img in lac_collection.images:
+    cr_count = img.cr_mask.data.sum() if img.cr_mask is not None else "N/A"
+    print(f"  {img.filename}  CR-flagged pixels: {cr_count}")
+
+# ------------------------------------------------------------------ #
+# 残差確認プロット
+# ------------------------------------------------------------------ #
+
+crj_collection.plot_lacosmic_residual(
+    lac_collection,
+    slit_index=SLIT_INDEX,
+    recession_velocity=RECESSION_VELOCITY,
+    v_range=V_RANGE,
+)

--- a/scripts/convolve2d_reference.py
+++ b/scripts/convolve2d_reference.py
@@ -1,0 +1,185 @@
+"""
+Numpyによる2次元畳み込み (convolve2d) 参考実装
+=================================================
+
+引用元:
+    aa_debdeb (2019)「【画像処理】Numpyで空間フィルタリング(畳み込み演算)」Qiita
+    https://qiita.com/aa_debdeb/items/e74eceb13ad8427b16c6
+
+概要:
+    scipy.signal.convolve2d を使わずに、NumPy の stride_tricks と einsum だけで
+    2次元畳み込みを実装した例。グレースケール・カラー両対応。
+
+実装のポイント:
+    - np.lib.stride_tricks.as_strided でカーネルサイズに合わせたスライディング
+      ウィンドウビューを作成することで、明示的なループを避けて高速化する。
+    - np.einsum('kl,ijkl->ij', kernel, strided_image) により、各ウィンドウに
+      対してカーネルとの要素積の総和を一括計算する。
+    - np.pad でエッジ補填 (boundary='edge') を行い、出力サイズを入力と同じに保つ。
+
+使用例:
+    - 平均化フィルタ (ボケ処理)
+    - Sobelフィルタ (エッジ検出)
+    天文画像への応用として、スカイバックグラウンドの空間平滑化や
+    コズミックレイ後の残差チェックなどに利用できる。
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+# ------------------------------------------------------------------ #
+#  内部関数: パディング
+# ------------------------------------------------------------------ #
+
+def _pad_singlechannel_image(image, kernel_shape, boundary):
+    """グレースケール画像 (2-D) をカーネル半幅分だけパディングする。"""
+    return np.pad(
+        image,
+        ((int(kernel_shape[0] / 2),), (int(kernel_shape[1] / 2),)),
+        boundary,
+    )
+
+
+def _pad_multichannel_image(image, kernel_shape, boundary):
+    """カラー画像 (3-D, shape: H×W×C) をカーネル半幅分だけパディングする。
+    チャンネル次元はパディングしない。"""
+    return np.pad(
+        image,
+        ((int(kernel_shape[0] / 2),), (int(kernel_shape[1] / 2),), (0,)),
+        boundary,
+    )
+
+
+# ------------------------------------------------------------------ #
+#  内部関数: 畳み込み本体
+# ------------------------------------------------------------------ #
+
+def _convolve2d(image, kernel):
+    """
+    グレースケール画像に対するパディング済み畳み込み。
+
+    Parameters
+    ----------
+    image : ndarray, shape (H, W)
+        パディング済み入力画像。
+    kernel : ndarray, shape (kH, kW)
+        畳み込みカーネル。
+
+    Returns
+    -------
+    ndarray, shape (H - kH + 1, W - kW + 1)
+
+    Notes
+    -----
+    np.lib.stride_tricks.as_strided で (out_H, out_W, kH, kW) の
+    ビュー配列を作り、np.einsum で一括内積計算を行う。
+    メモリコピーを伴わないため大きな画像でも比較的省メモリ。
+    """
+    shape = (
+        image.shape[0] - kernel.shape[0] + 1,
+        image.shape[1] - kernel.shape[1] + 1,
+    ) + kernel.shape
+    strides = image.strides * 2
+    strided_image = np.lib.stride_tricks.as_strided(image, shape, strides)
+    return np.einsum('kl,ijkl->ij', kernel, strided_image)
+
+
+def _convolve2d_multichannel(image, kernel):
+    """カラー画像 (H×W×C) に対してチャンネルごとに _convolve2d を適用する。"""
+    out = np.empty((
+        image.shape[0] - kernel.shape[0] + 1,
+        image.shape[1] - kernel.shape[1] + 1,
+        image.shape[2],
+    ))
+    for i in range(image.shape[2]):
+        out[:, :, i] = _convolve2d(image[:, :, i], kernel)
+    return out
+
+
+# ------------------------------------------------------------------ #
+#  公開関数
+# ------------------------------------------------------------------ #
+
+def convolve2d(image, kernel, boundary='edge'):
+    """
+    NumPy だけで実装した 2-D 畳み込み関数。
+
+    Parameters
+    ----------
+    image : ndarray
+        入力画像。shape は (H, W) または (H, W, C)。
+        画素値は float 推奨 (整数の場合は事前に正規化すること)。
+    kernel : ndarray, shape (kH, kW)
+        畳み込みカーネル。
+    boundary : str or None, default 'edge'
+        np.pad に渡すパディング方式。
+        'edge'  : 端の画素値で埋める (デフォルト)
+        'reflect': 鏡面反射
+        None    : パディングなし (出力サイズが小さくなる)
+
+    Returns
+    -------
+    ndarray
+        入力と同じ空間サイズ (boundary が None でない場合) の畳み込み結果。
+    """
+    if image.ndim == 2:
+        pad_image = (
+            _pad_singlechannel_image(image, kernel.shape, boundary)
+            if boundary is not None
+            else image
+        )
+        return _convolve2d(pad_image, kernel)
+    elif image.ndim == 3:
+        pad_image = (
+            _pad_multichannel_image(image, kernel.shape, boundary)
+            if boundary is not None
+            else image
+        )
+        return _convolve2d_multichannel(pad_image, kernel)
+    else:
+        raise ValueError(f"image must be 2-D or 3-D, got {image.ndim}-D")
+
+
+# ------------------------------------------------------------------ #
+#  使用例
+# ------------------------------------------------------------------ #
+
+if __name__ == '__main__':
+    # --- 画像読み込み & 正規化 ---
+    image_name = 'sample.png'   # 任意の画像ファイルに変更すること
+    original_image = plt.imread(image_name)
+    if np.issubdtype(original_image.dtype, np.integer):
+        original_image = original_image / np.iinfo(original_image.dtype).max
+
+    # --- 平均化フィルタ (3×3) ---
+    def create_averaging_kernel(size):
+        return np.full(size, 1.0 / (size[0] * size[1]))
+
+    averaging3x3_image = convolve2d(original_image, create_averaging_kernel((3, 3)))
+    averaging5x5_image = convolve2d(original_image, create_averaging_kernel((5, 5)))
+
+    # --- Sobel フィルタ (水平方向エッジ検出) ---
+    gray_image = (
+        0.2116 * original_image[:, :, 0]
+        + 0.7152 * original_image[:, :, 1]
+        + 0.0722 * original_image[:, :, 2]
+    )
+    sobel_h_kernel = np.array([
+        [ 1,  2,  1],
+        [ 0,  0,  0],
+        [-1, -2, -1],
+    ])
+    sobel_h_image = convolve2d(gray_image, sobel_h_kernel)
+    value_range = max(abs(sobel_h_image.min()), abs(sobel_h_image.max()))
+
+    # --- 表示 ---
+    fig, axes = plt.subplots(1, 4, figsize=(16, 4))
+    axes[0].imshow(original_image);        axes[0].set_title('Original')
+    axes[1].imshow(averaging3x3_image);    axes[1].set_title('Avg 3x3')
+    axes[2].imshow(averaging5x5_image);    axes[2].set_title('Avg 5x5')
+    axes[3].imshow(sobel_h_image, cmap='bwr', vmin=-value_range, vmax=value_range)
+    axes[3].set_title('Sobel H')
+    plt.colorbar(axes[3].images[0], ax=axes[3])
+    plt.tight_layout()
+    plt.show()

--- a/scripts/run_lacosmic.py
+++ b/scripts/run_lacosmic.py
@@ -30,7 +30,6 @@ LA_COSMIC_PARAMS = dict(
     contrast=5.0,
     cr_threshold=5.0,
     neighbor_threshold=5.0,
-    error=5.0,
 )
 
 # 除外したいファイルの stem を列挙（不要なら空のまま）
@@ -57,7 +56,7 @@ readers = ReaderCollection.from_paths(instrument.path_list)
 collection = ImageCollection.from_readers(readers, dq_flags=DQ_FLAGS, **LA_COSMIC_PARAMS)
 
 # --- LA-Cosmic 適用 ---
-#lac_collection = collection.remove_cosmic_ray()
+lac_collection = collection.remove_cosmic_ray(maxiter=1)
 
 # --- _lac.fits として書き出し ---
 #output_paths = lac_collection.write_fits(output_dir=OUTPUT_DIR, overwrite=True)
@@ -66,15 +65,6 @@ collection = ImageCollection.from_readers(readers, dq_flags=DQ_FLAGS, **LA_COSMI
 #for p in output_paths:
 #    print(f"  {p}")
 
-
-# --- ラプラシアン ---
-
-from matplotlib.colors import AsinhNorm
-sci_image = collection[0].sci
-lap_sci_image = sci_image.convert_to_laplacian()
-lap_sci_image.imshow(cmap="coolwarm", norm=AsinhNorm())
-
-
 # ---　lacosmic image sample ---
 
 from lacosmic.utils import make_cosmic_rays, make_gaussian_sources
@@ -82,7 +72,3 @@ shape = (512, 512)
 data, error = make_gaussian_sources(shape, seed=0)
 cr_img = make_cosmic_rays(shape, n_cosmics=200, seed=0)
 data2 = data + cr_img  
-
-sample_image = ImageUnit(data=data2, header=fits.Header())
-lap_sample_image = sample_image.convert_to_laplacian()
-lap_sample_image.imshow(cmap="coolwarm", norm=AsinhNorm())

--- a/scripts/run_lacosmic.py
+++ b/scripts/run_lacosmic.py
@@ -8,6 +8,7 @@ ipython での実行:
 """
 
 from pathlib import Path
+import matplotlib.pyplot as plt
 
 from stis_analysis.core.fits_reader import ReaderCollection
 from stis_analysis.core.instrument import InstrumentModel
@@ -17,8 +18,8 @@ from stis_analysis.lacosmic import ImageCollection
 # 設定（必要に応じて変更）
 # ------------------------------------------------------------------ #
 
-HST_DIR = Path("../../HST")            # _flt.fits があるルートディレクトリ
-OUTPUT_DIR = Path("../../output/lac")  # _lac.fits の出力先
+HST_DIR = Path("../data/HST")            # _flt.fits があるルートディレクトリ
+OUTPUT_DIR = Path("../data/output/lac")  # _lac.fits の出力先
 
 SUFFIX = "_crj"
 DEPTH = 1  # HST/o56502010/o56502010_crj.fits の 1 階層下
@@ -56,11 +57,21 @@ readers = ReaderCollection.from_paths(instrument.path_list)
 collection = ImageCollection.from_readers(readers, dq_flags=DQ_FLAGS, **LA_COSMIC_PARAMS)
 
 # --- LA-Cosmic 適用 ---
-lac_collection = collection.remove_cosmic_ray()
+#lac_collection = collection.remove_cosmic_ray()
 
 # --- _lac.fits として書き出し ---
-output_paths = lac_collection.write_fits(output_dir=OUTPUT_DIR, overwrite=True)
+#output_paths = lac_collection.write_fits(output_dir=OUTPUT_DIR, overwrite=True)
 
-print(f"\nOutput ({len(output_paths)} files):")
-for p in output_paths:
-    print(f"  {p}")
+#print(f"\nOutput ({len(output_paths)} files):")
+#for p in output_paths:
+#    print(f"  {p}")
+
+
+# --- ラプラシアン ---
+
+sci_image = collection[3].sci
+lap_sci_image = sci_image.convert_to_laplacian()
+
+plt.imshow(lap_sci_image.data, cmap="viridis")
+plt.colorbar()
+plt.show()

--- a/scripts/run_lacosmic.py
+++ b/scripts/run_lacosmic.py
@@ -9,9 +9,9 @@ ipython での実行:
 
 from pathlib import Path
 import matplotlib.pyplot as plt
+from astropy.io import fits
 
-from stis_analysis.core.fits_reader import ReaderCollection
-from stis_analysis.core.instrument import InstrumentModel
+from stis_analysis.core import InstrumentModel, ReaderCollection, ImageUnit
 from stis_analysis.lacosmic import ImageCollection
 
 # ------------------------------------------------------------------ #
@@ -69,9 +69,20 @@ collection = ImageCollection.from_readers(readers, dq_flags=DQ_FLAGS, **LA_COSMI
 
 # --- ラプラシアン ---
 
-sci_image = collection[3].sci
+from matplotlib.colors import AsinhNorm
+sci_image = collection[0].sci
 lap_sci_image = sci_image.convert_to_laplacian()
+lap_sci_image.imshow(cmap="coolwarm", norm=AsinhNorm())
 
-plt.imshow(lap_sci_image.data, cmap="viridis")
-plt.colorbar()
-plt.show()
+
+# ---　lacosmic image sample ---
+
+from lacosmic.utils import make_cosmic_rays, make_gaussian_sources
+shape = (512, 512)
+data, error = make_gaussian_sources(shape, seed=0)
+cr_img = make_cosmic_rays(shape, n_cosmics=200, seed=0)
+data2 = data + cr_img  
+
+sample_image = ImageUnit(data=data2, header=fits.Header())
+lap_sample_image = sample_image.convert_to_laplacian()
+lap_sample_image.imshow(cmap="coolwarm", norm=AsinhNorm())

--- a/src/stis_analysis/core/image.py
+++ b/src/stis_analysis/core/image.py
@@ -85,15 +85,6 @@ class ImageUnit:
         data = self.data.astype(np.uint8) if self.data.dtype == bool else self.data
         return fits.ImageHDU(data=data, header=self.header)
 
-    def convert_to_laplacian(self) -> ImageUnit:
-        """画像データをラプラシアン行列に変換する."""
-        shape = self.data.shape
-        size = min(shape[0], shape[1])
-        start_x = (shape[0] - size) // 2
-        start_y = (shape[1] - size) // 2
-        data = self.data[start_x: start_x + size, start_y: start_y + size]
-        return replace(self, data=laplacian(data))
-
     def imshow(self, ax=None, **kwargs):
         import matplotlib.pyplot as plt
         if ax is None:

--- a/src/stis_analysis/core/image.py
+++ b/src/stis_analysis/core/image.py
@@ -18,7 +18,6 @@ from typing import cast
 import numpy as np
 from astropy.io import fits  # type: ignore
 from scipy.sparse.csgraph import laplacian
-from matplotlib.colors import Normalize, AsinhNorm
 
 
 
@@ -93,14 +92,20 @@ class ImageUnit:
         start_x = (shape[0] - size) // 2
         start_y = (shape[1] - size) // 2
         data = self.data[start_x: start_x + size, start_y: start_y + size]
-        return replace(self, data=laplacian(data), cmap="coolwarm", )
+        return replace(self, data=laplacian(data))
 
     def imshow(self, ax=None, **kwargs):
         import matplotlib.pyplot as plt
         if ax is None:
             fig, ax = plt.subplots()
-
-        cs = ax.imshow(self.data, **kwargs)
+        
+        wavelength = self.wavelength
+        if type(wavelength) != type(None):
+            wavelength = cast(np.ndarray, wavelength)
+            extent = (wavelength[0], wavelength[-1], 0, self.naxis1)
+        else:
+            extent = None
+        cs = ax.imshow(self.data, **kwargs, extent = extent)
         plt.colorbar(cs, ax=ax)
         ax.set_xlabel(r'wavelength [$\AA$]')
         ax.set_ylabel('spatial [pixel]')

--- a/src/stis_analysis/core/image.py
+++ b/src/stis_analysis/core/image.py
@@ -12,11 +12,14 @@ ImageUnit は spectrum_package と stis_la_cosmic の両実装をマージした
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import cast
 
 import numpy as np
 from astropy.io import fits  # type: ignore
+from scipy.sparse.csgraph import laplacian
+from matplotlib.colors import Normalize, AsinhNorm
+
 
 
 @dataclass(frozen=True)
@@ -82,3 +85,23 @@ class ImageUnit:
         """
         data = self.data.astype(np.uint8) if self.data.dtype == bool else self.data
         return fits.ImageHDU(data=data, header=self.header)
+
+    def convert_to_laplacian(self) -> ImageUnit:
+        """画像データをラプラシアン行列に変換する."""
+        shape = self.data.shape
+        size = min(shape[0], shape[1])
+        start_x = (shape[0] - size) // 2
+        start_y = (shape[1] - size) // 2
+        data = self.data[start_x: start_x + size, start_y: start_y + size]
+        return replace(self, data=laplacian(data), cmap="coolwarm", )
+
+    def imshow(self, ax=None, **kwargs):
+        import matplotlib.pyplot as plt
+        if ax is None:
+            fig, ax = plt.subplots()
+
+        cs = ax.imshow(self.data, **kwargs)
+        plt.colorbar(cs, ax=ax)
+        ax.set_xlabel(r'wavelength [$\AA$]')
+        ax.set_ylabel('spatial [pixel]')
+        return ax

--- a/src/stis_analysis/core/wave_constants.py
+++ b/src/stis_analysis/core/wave_constants.py
@@ -1,0 +1,28 @@
+# currently used by
+#  stis_reduce
+#  prep_ngc1068
+#  prep_ngc4151
+#  prep_circinus
+
+# speed of light
+c_kms = 2.99792458e5  # km/s
+
+# vacuum wavelength for various emission/absorption lines
+oiii4959_vac = 4960.295
+oiii5007_vac = 5008.239
+halpha_vac   = 6564.614
+hbeta_vac    = 4862.721
+
+# S.T.P.
+oiii4959_stp = 4958.911
+oiii5007_stp = 5006.843
+halpha_stp   = 6562.801
+hbeta_stp    = 4861.363
+CaII8542_stp = 8542.090
+
+nii6548_stp  = 6548.050
+nii6583_stp  = 6583.460
+
+# line ratios
+oiii5007_oiii4959 = 2.98   # Dimitrijevic+07
+nii6583_nii6548 = 3.049    # Dojčinović+22

--- a/src/stis_analysis/lacosmic/image.py
+++ b/src/stis_analysis/lacosmic/image.py
@@ -11,6 +11,7 @@ STIS FITS ファイルから読み込んだ画像データを管理し、
 - ImageCollection.imshow_mask(): dq_mask=None の場合の fallback を追加 (バグ修正)
 """
 
+import math
 from typing import Literal
 import warnings
 from dataclasses import dataclass, replace
@@ -24,6 +25,7 @@ from scipy.ndimage import median_filter  # type: ignore
 
 from stis_analysis.core.image import ImageUnit
 from stis_analysis.core.fits_reader import ReaderCollection, STISFitsReader
+from stis_analysis.core.wave_constants import c_kms, oiii5007_stp
 
 
 @dataclass(frozen=True)
@@ -123,6 +125,14 @@ class ImageModel:
         except KeyError:
             dq = None
             dq_mask = None
+
+        # LACOSMIC 拡張（HDU 4）があれば読み込む
+        cr_mask = None
+        for hdu_idx, hdr in reader.headers.items():
+            if hdr.get("EXTNAME") == "LACOSMIC" and hdu_idx in reader.data:
+                cr_mask = ImageUnit(data=reader.data[hdu_idx], header=hdr)
+                break
+
         return cls(
             primary_header=reader.header(0),
             sci=ImageUnit(
@@ -132,6 +142,7 @@ class ImageModel:
             err=err,
             dq=dq,
             dq_mask=dq_mask,
+            cr_mask=cr_mask,
             source_path=reader.filename.parent,
             dq_flags=dq_flags,
         )
@@ -421,6 +432,98 @@ class ImageModel:
             hdu_list.append(self.cr_mask.to_hdu())
         fits.HDUList(hdu_list).writeto(output_path, overwrite=overwrite)
         return output_path
+
+    def plot_lacosmic_residual(
+        self,
+        other: "ImageModel",
+        slit_index: int,
+        recession_velocity: float,
+        rest_wavelength: float = oiii5007_stp,
+        v_range: tuple[float, float] = (-3000.0, 3000.0),
+        labels: tuple[str, str] = ("before", "after (LA-Cosmic)"),
+        axes=None,
+    ) -> tuple:  # pyright: ignore
+        """LA-Cosmic 除去残差スペクトルを 2 段プロットで確認する.
+
+        上段: self (before) と other (after) スペクトルを重ね描き。
+        下段: 残差 = before − after（LA-Cosmic が除去した分）。
+              CR マスクされたピクセルを赤い点でマーク。
+
+        Parameters
+        ----------
+        other : ImageModel
+            LA-Cosmic 処理後の画像（after）
+        slit_index : int
+            確認するスリット行のインデックス
+        recession_velocity : float
+            銀河の後退速度 [km/s]
+        rest_wavelength : float, optional
+            速度 v=0 の基準静止波長 [Å]（デフォルト: oiii5007_stp）
+        v_range : tuple[float, float], optional
+            速度表示範囲 [km/s]（デフォルト: (-3000, 3000)）
+        labels : tuple[str, str], optional
+            凡例ラベル（before, after の順）
+        axes : tuple | None, optional
+            (ax_top, ax_bottom) の Axes タプル。None の場合は新規作成。
+
+        Returns
+        -------
+        tuple
+            (ax_top, ax_bottom) の Axes タプル
+        """
+        z = recession_velocity / c_kms
+        lambda_ref = rest_wavelength * (1.0 + z)
+
+        wl = self.sci.wavelength
+        if wl is None:
+            raise ValueError("波長情報が存在しません（WCS が設定されていません）")
+
+        vel = c_kms * (wl / lambda_ref - 1.0)
+        spec_before = self.sci.data[slit_index, :]
+        spec_after = other.sci.data[slit_index, :]
+        residual = spec_before - spec_after
+
+        v_lo, v_hi = v_range
+        mask_v = (vel >= v_lo) & (vel <= v_hi)
+
+        cr_row = (
+            other.cr_mask.data[slit_index, :].astype(bool)
+            if other.cr_mask is not None
+            else np.zeros(len(spec_before), dtype=bool)
+        )
+
+        if axes is None:
+            _, (ax_top, ax_bottom) = plt.subplots(
+                2, 1, figsize=(8, 6), sharex=True,
+                gridspec_kw={"height_ratios": [2, 1]},
+            )
+        else:
+            ax_top, ax_bottom = axes
+
+        # 上段: before vs after
+        ax_top.plot(vel[mask_v], spec_before[mask_v],
+                    color="steelblue", lw=0.8, alpha=0.9, label=labels[0])
+        ax_top.plot(vel[mask_v], spec_after[mask_v],
+                    color="tomato", lw=0.8, alpha=0.9, label=labels[1])
+        ax_top.set_ylabel("Counts")
+        ax_top.set_title(f"{self.filename}  slit={slit_index}")
+        ax_top.legend(fontsize="small")
+
+        # 下段: 残差
+        ax_bottom.plot(vel[mask_v], residual[mask_v],
+                       color="dimgray", lw=0.8, label="residual (before − after)")
+        cr_in_range = cr_row & mask_v
+        if cr_in_range.any():
+            ax_bottom.scatter(
+                vel[cr_in_range], residual[cr_in_range],
+                color="red", s=12, zorder=5, label="CR-flagged pixels",
+            )
+        ax_bottom.axhline(0, color="k", lw=0.5, ls="--")
+        ax_bottom.set_xlabel("Velocity [km/s]")
+        ax_bottom.set_ylabel("Residual")
+        ax_bottom.legend(fontsize="small")
+
+        return ax_top, ax_bottom
 
     def plot_spectrum(
         self,
@@ -972,6 +1075,91 @@ class ImageCollection:
         )
         fig.text(0.5, 0.01, param_text, ha="center", va="bottom", fontsize=8)
         fig.tight_layout(rect=(0.0, 0.05, 1.0, 0.93))
+
+    def plot_lacosmic_residual(
+        self,
+        other: "ImageCollection",
+        slit_index: int,
+        recession_velocity: float,
+        rest_wavelength: float = oiii5007_stp,
+        v_range: tuple[float, float] = (-3000.0, 3000.0),
+        labels: tuple[str, str] = ("before", "after (LA-Cosmic)"),
+        save_path: Path | str | None = None,
+    ) -> np.ndarray:
+        """LA-Cosmic 残差を全画像で 2 段 × n_images タイル表示する.
+
+        各列が 1 枚の画像に対応し、上段行にスペクトル比較、
+        下段行に残差スペクトルを配置する。
+
+        Parameters
+        ----------
+        other : ImageCollection
+            LA-Cosmic 処理後のコレクション（after）
+        slit_index : int
+            確認するスリット行のインデックス
+        recession_velocity : float
+            銀河の後退速度 [km/s]
+        rest_wavelength : float, optional
+            速度 v=0 の基準静止波長 [Å]（デフォルト: oiii5007_stp）
+        v_range : tuple[float, float], optional
+            速度表示範囲 [km/s]（デフォルト: (-3000, 3000)）
+        labels : tuple[str, str], optional
+            凡例ラベル（before, after の順）
+        save_path : Path | str | None, optional
+            保存先パス。None の場合は保存しない。
+
+        Returns
+        -------
+        np.ndarray
+            Axes の 2D 配列（shape: (2 * nrows, ncols)）
+        """
+        n = len(self.images)
+        if n == 0:
+            raise ValueError("画像が存在しません。")
+        if len(other.images) != n:
+            raise ValueError(
+                f"画像数が一致しません: self={n}, other={len(other.images)}"
+            )
+
+        ncols = min(n, 7)
+        nrows = math.ceil(n / ncols)
+        total_rows = 2 * nrows
+
+        fig, axes_2d = plt.subplots(
+            total_rows, ncols,
+            figsize=(2.5 * ncols, 2.5 * total_rows),
+            squeeze=False,
+        )
+
+        for i, (img_before, img_after) in enumerate(zip(self.images, other.images)):
+            row_base = (i // ncols) * 2
+            col = i % ncols
+            ax_top = axes_2d[row_base, col]
+            ax_bottom = axes_2d[row_base + 1, col]
+            img_before.plot_lacosmic_residual(
+                img_after,
+                slit_index=slit_index,
+                recession_velocity=recession_velocity,
+                rest_wavelength=rest_wavelength,
+                v_range=v_range,
+                labels=labels,
+                axes=(ax_top, ax_bottom),
+            )
+
+        # 余ったサブプロットを非表示
+        for i in range(n, nrows * ncols):
+            row_base = (i // ncols) * 2
+            col = i % ncols
+            axes_2d[row_base, col].set_visible(False)
+            axes_2d[row_base + 1, col].set_visible(False)
+
+        plt.tight_layout()
+
+        if save_path is not None:
+            fig.savefig(save_path)
+
+        plt.show()
+        return axes_2d
 
     def __len__(self) -> int:
         return len(self.images)

--- a/src/stis_analysis/lacosmic/image.py
+++ b/src/stis_analysis/lacosmic/image.py
@@ -214,6 +214,24 @@ class ImageModel:
             dq_mask=combined_mask,
         )
 
+    @property
+    def gain(self) -> float:
+        """ゲイン [e-/ADU]（Primary Header の ATODGAIN）."""
+        val = self.primary_header.get("ATODGAIN")
+        if val is None:
+            warnings.warn(f"{self.filename}: ATODGAIN not found in header, using 1.0")
+            return 1.0
+        return float(val)  # type: ignore[arg-type]
+
+    @property
+    def read_noise(self) -> float:
+        """リードノイズ [e-]（Primary Header の READNSE）."""
+        val = self.primary_header.get("READNSE")
+        if val is None:
+            warnings.warn(f"{self.filename}: READNSE not found in header, using 2.5")
+            return 2.5
+        return float(val)  # type: ignore[arg-type]
+
     def remove_cosmic_ray(
         self,
         contrast: float = 5.0,
@@ -259,6 +277,8 @@ class ImageModel:
             neighbor_threshold,
             error=error * np.ones(self.shape) if error is not None else None,
             mask=preprocessed.dq_mask,
+            effective_gain=self.gain,
+            readnoise=self.read_noise,
             **kwargs,
         )
 

--- a/src/stis_analysis/lacosmic/image.py
+++ b/src/stis_analysis/lacosmic/image.py
@@ -84,6 +84,8 @@ class ImageModel:
             f"  source_path={self.source_path}\n"
             f"  dq_flags={self.dq_flags}\n"
             f"  {dq_mask_info},\n"
+            f"  gain={self.gain}\n"
+            f"  read_noise={self.read_noise}\n"
             f")"
         )
 
@@ -237,7 +239,6 @@ class ImageModel:
         contrast: float = 5.0,
         cr_threshold: float = 5,
         neighbor_threshold: float = 5,
-        error: float | None = 5,
         mask_negative: bool = True,
         **kwargs,
     ) -> Self:
@@ -255,8 +256,6 @@ class ImageModel:
             宇宙線検出のシグマクリッピング閾値（デフォルト: 5）
         neighbor_threshold : float, optional
             近傍ピクセルの検出閾値（デフォルト: 5）
-        error : float | None, optional
-            誤差配列のスケール係数（デフォルト: 5）
         mask_negative : bool, optional
             True の場合、負の値を持つピクセルもマスク対象にする（デフォルト: True）
         **kwargs
@@ -275,7 +274,6 @@ class ImageModel:
             contrast,
             cr_threshold,
             neighbor_threshold,
-            error=error * np.ones(self.shape) if error is not None else None,
             mask=preprocessed.dq_mask,
             effective_gain=self.gain,
             readnoise=self.read_noise,
@@ -696,15 +694,12 @@ class ImageCollection:
         宇宙線検出のシグマクリッピング閾値（デフォルト: 5）
     neighbor_threshold : float
         近傍ピクセルの検出閾値（デフォルト: 5）
-    error : float
-        誤差配列のスケール係数（デフォルト: 5）
     """
 
     images: list[ImageModel]
     contrast: float = 5.0
     cr_threshold: float = 5
     neighbor_threshold: float = 5
-    error: float = 5
 
     def __repr__(self) -> str:
         return (
@@ -712,7 +707,6 @@ class ImageCollection:
             + f"contrast={self.contrast}, \n"
             + f"cr_threshold={self.cr_threshold}, \n"
             + f"neighbor_threshold={self.neighbor_threshold}, \n"
-            + f"error={self.error})\n"
         )
 
     @classmethod
@@ -723,7 +717,6 @@ class ImageCollection:
         contrast: float = 5.0,
         cr_threshold: float = 5,
         neighbor_threshold: float = 5,
-        error: float = 5,
     ) -> Self:
         """ReaderCollection から ImageCollection を生成する.
 
@@ -739,8 +732,6 @@ class ImageCollection:
             宇宙線検出のシグマクリッピング閾値（デフォルト: 5）
         neighbor_threshold : float, optional
             近傍ピクセルの検出閾値（デフォルト: 5）
-        error : float, optional
-            誤差配列のスケール係数（デフォルト: 5）
 
         Returns
         -------
@@ -756,7 +747,6 @@ class ImageCollection:
             contrast=contrast,
             cr_threshold=cr_threshold,
             neighbor_threshold=neighbor_threshold,
-            error=error,
         )
 
     def interpolate_bad_pixels(self, **kwargs) -> Self:
@@ -800,7 +790,6 @@ class ImageCollection:
                 contrast=self.contrast,
                 cr_threshold=self.cr_threshold,
                 neighbor_threshold=self.neighbor_threshold,
-                error=self.error,
                 **kwargs,
             )
             for image in self.images
@@ -1090,8 +1079,7 @@ class ImageCollection:
         param_text = (
             f"contrast={self.contrast}  "
             f"cr_threshold={self.cr_threshold}  "
-            f"neighbor_threshold={self.neighbor_threshold}  "
-            f"error={self.error}"
+            f"neighbor_threshold={self.neighbor_threshold}"
         )
         fig.text(0.5, 0.01, param_text, ha="center", va="bottom", fontsize=8)
         fig.tight_layout(rect=(0.0, 0.05, 1.0, 0.93))

--- a/src/stis_analysis/processing/wave_constants.py
+++ b/src/stis_analysis/processing/wave_constants.py
@@ -1,28 +1,3 @@
-# currently used by
-#  stis_reduce
-#  prep_ngc1068
-#  prep_ngc4151
-#  prep_circinus
-
-# speed of light
-c_kms = 2.99792458e5  # km/s
-
-# vacuum wavelength for various emission/absorption lines
-oiii4959_vac = 4960.295
-oiii5007_vac = 5008.239
-halpha_vac   = 6564.614
-hbeta_vac    = 4862.721
-
-# S.T.P.
-oiii4959_stp = 4958.911
-oiii5007_stp = 5006.843
-halpha_stp   = 6562.801
-hbeta_stp    = 4861.363
-CaII8542_stp = 8542.090
-
-nii6548_stp  = 6548.050
-nii6583_stp  = 6583.460
-
-# line ratios
-oiii5007_oiii4959 = 2.98   # Dimitrijevic+07
-nii6583_nii6548 = 3.049    # Dojčinović+22
+# 後方互換性のため stis_analysis.core.wave_constants を再エクスポートする。
+# 新規コードは stis_analysis.core.wave_constants から直接インポートすること。
+from stis_analysis.core.wave_constants import *  # noqa: F401, F403


### PR DESCRIPTION
## このPRで何をしたか

LA-Cosmic が輝線フラックスを誤って除去していないかを確認するための診断ツールを追加しました。
加えて、LA-Cosmic のノイズモデルに正しい gain / readnoise をヘッダーから読み込んで渡すよう改善しています。

---

## 背景と経緯

OIII λ5007 等の輝線の高輝度ピクセルが宇宙線と誤判定され、フラックスが削られるという問題（Issue #10）があります。
以前 `wip/emission-line-protection` ブランチで「保護マスク」を使った解決を試みましたが、うまくいかずに中断しました。

今回はまず **「どの程度・どのピクセルが削られているか」を目視できる状態にする** ことを目的にしています。
原因分析が先、対策は後という方針です。

---

## 変更内容

### 1. `lacosmic/image.py` — 残差確認メソッドの追加

**`ImageModel.plot_lacosmic_residual(other, slit_index, recession_velocity, ...)`**

処理前（CRJ）と処理後（LAC）の1枚ずつを比較する2段プロットを生成します。

- 上段: before（青）と after（赤橙）のスペクトルを重ね描き
- 下段: 残差 = before − after（LA-Cosmic が除去した量）。CR フラグされたピクセルは赤点でマーク

速度軸（km/s）で表示するので、輝線が v ≈ 0 km/s に来ます。
**赤点が v ≈ 0 付近に集中していれば輝線フラックスが削られている証拠です。**

**`ImageCollection.plot_lacosmic_residual(other, slit_index, recession_velocity, ...)`**

上記を全画像でタイル表示します。7枚全部を一度に見渡せます。

### 2. `lacosmic/image.py` — from_reader の改善

`_lac.fits` をファイルから再読み込みした際に、HDU 4 の LACOSMIC 拡張（CR マスク）も復元するようにしました。
これにより、ipython セッションをまたいでも `cr_mask` が `None` にならず、残差プロットで赤点を表示できます。

### 3. `lacosmic/image.py` — gain / readnoise プロパティの追加（wip ブランチから取り込み）

`wip/emission-line-protection`（コミット `bb5d3b5`）から以下を取り込みました。

```python
@property
def gain(self) -> float:
    """Primary Header の ATODGAIN を返す"""

@property
def read_noise(self) -> float:
    """Primary Header の READNSE を返す"""
```

`remove_cosmics()` に `effective_gain` と `readnoise` を渡すことで、
LA-Cosmic が正しいノイズモデルで動作するようになります。
これまではデフォルト値（gain=1.0, readnoise=0.0）が使われていました。

### 4. `core/wave_constants.py` — 新設

`c_kms` や `oiii5007_stp` 等の定数の正規の場所を `processing/` から `core/` に移しました。

**理由:** `lacosmic/image.py` から `processing/wave_constants.py` を直接インポートしようとすると、
`lacosmic → processing → lacosmic` という循環インポートが発生するためです。
`processing/wave_constants.py` は後方互換のために `core/` への re-export に変更しています。

### 5. `scripts/check_lacosmic_residual.py` — 確認スクリプト

ipython から実行するだけで残差プロットが出るスクリプトです。

```python
%run scripts/check_lacosmic_residual.py
```

---

## テスト結果

- `poetry run pytest`: **108 tests pass**
- `poetry run pyright`: **0 errors**

---

## レビューで確認してほしいこと

1. `gain` / `read_noise` の Header キー名（`ATODGAIN`, `READNSE`）が実データで正しく読めているか
   → `collection[0].gain` と `collection[0].read_noise` を ipython で確認してください

2. `check_lacosmic_residual.py` のパス設定（`CRJ_DIR`, `LAC_DIR`）が環境に合っているか確認してください

3. 残差プロットで v ≈ 0 km/s 付近に赤点が見えるかどうか
   → これが Issue #10 の定量的な確認になります

---

## 関連

- Issue #10: LA-Cosmic 輝線誤検出問題
- `wip/emission-line-protection`: 過去の保護マスク試み（差し戻し済み）